### PR TITLE
feat: Use conventional api key as token defaults

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -17,15 +17,18 @@ lang-chain-url = "http://localhost:8000"
 ollama-url = "http://localhost:11434"
 
 # OpenAI API token when using the OpenAI backend.
+# Defaults to the environment variable OPENAI_API_TOKEN if set
 # open-ai-token = ""
 
 # OpenAI API URL when using the OpenAI backend. Can be swapped to a compatible proxy.
 open-ai-url = "https://api.openai.com"
 
 # Anthropic's Claude API token when using the Claude backend.
+# Defaults to the environment variable ANTHROPIC_API_TOKEN if set
 # claude-token = ""
 
 # Google Gemini API token when using the Gemini backend.
+# Defaults to the environment variable GEMINI_API_TOKEN if set
 # gemini-token = ""
 
 # Sets code syntax highlighting theme. [possible values: base16-github, base16-monokai, base16-one-light, base16-onedark, base16-seti]

--- a/src/configuration/config.rs
+++ b/src/configuration/config.rs
@@ -92,6 +92,9 @@ impl Config {
             }
         }
 
+        let anthropic_api_key = env::var("ANTHROPIC_API_KEY").unwrap_or_default();
+        let openai_api_key = env::var("OPENAI_API_KEY").unwrap_or_default();
+        let gemini_api_key = env::var("GEMINI_API_KEY").unwrap_or_default();
         let res = match key {
             ConfigKey::Backend => &default_backend,
             ConfigKey::BackendHealthCheckTimeout => "1000",
@@ -99,10 +102,10 @@ impl Config {
             ConfigKey::Model => "",
             ConfigKey::LangChainURL => "http://localhost:8000",
             ConfigKey::OllamaURL => "http://localhost:11434",
-            ConfigKey::OpenAiToken => "",
+            ConfigKey::OpenAiToken => openai_api_key.as_str(),
             ConfigKey::OpenAiURL => "https://api.openai.com",
-            ConfigKey::ClaudeToken => "",
-            ConfigKey::GeminiToken => "",
+            ConfigKey::ClaudeToken => anthropic_api_key.as_str(),
+            ConfigKey::GeminiToken => gemini_api_key.as_str(),
             ConfigKey::Theme => "base16-onedark",
             ConfigKey::ThemeFile => "",
 

--- a/src/configuration/config_test.rs
+++ b/src/configuration/config_test.rs
@@ -1,11 +1,19 @@
 use anyhow::Result;
+use std::env;
 use test_utils::insta_snapshot;
 
 use super::Config;
 use crate::application::cli;
 
+fn teardown_default_api_keys() {
+    env::remove_var("ANTHROPIC_API_KEY");
+    env::remove_var("OPENAI_API_KEY");
+    env::remove_var("GEMINI_API_KEY");
+}
+
 #[test]
 fn it_serializes_to_valid_toml() {
+    teardown_default_api_keys();
     let res = Config::serialize_default(cli::build());
     let toml_res = res.parse::<toml_edit::DocumentMut>();
     assert!(toml_res.is_ok());

--- a/src/configuration/config_test.rs
+++ b/src/configuration/config_test.rs
@@ -1,5 +1,6 @@
-use anyhow::Result;
 use std::env;
+
+use anyhow::Result;
 use test_utils::insta_snapshot;
 
 use super::Config;


### PR DESCRIPTION
The documentation for the OpenAI/ChatGPT, Anthropic/Claude, and Google/Gemini models each use a conventional environment variable to hold the model's API key:

| Model | Convention | Docs
| - | - | - 
| OpenAI/ChatGPT | `OPENAI_API_KEY` | https://platform.openai.com/docs/quickstart#create-and-export-an-api-key
| Anthropic/Claude | `ANTHROPIC_API_KEY` | https://docs.anthropic.com/en/docs/initial-setup#set-your-api-key
| Google/Gemini | `GEMINI_API_KEY` | https://ai.google.dev/gemini-api/docs/api-key

 This value is overridden by the `config.toml` file and by the `OATMEAL_OPENAI_TOKEN`, `OATMEAL_CLAUDE_TOKEN`, and `OATMEAL_GEMINI_TOKEN` environment variables. 